### PR TITLE
bug fixed, post subcategories

### DIFF
--- a/client/src/components/Categories/AddCategories.jsx
+++ b/client/src/components/Categories/AddCategories.jsx
@@ -97,6 +97,7 @@ export default function AddCategories (props){
                 </div>
             
                 <select className={styles.select} disabled={disableSelect} onChange={(e) => {handleSelect(e)}}>
+                    <option value="categories">Categories:</option>
                 {categories?.map(el => {
                     return(
                         <option value={el.id} key={el.id}>{el.name}</option>


### PR DESCRIPTION
lucas ya arregle el problema de la creación de subcategoría, suma una etiqueta que dice categorías al comienzo del select para que el admin pueda orientarse y ya crea correctamente la subcategoría.